### PR TITLE
Add the supported languages of the multilingual model

### DIFF
--- a/custom_components/elevenlabs_tts/tts.py
+++ b/custom_components/elevenlabs_tts/tts.py
@@ -38,7 +38,7 @@ class ElevenLabsProvider(Provider):
     @property
     def supported_languages(self) -> list[str]:
         """Return list of supported languages."""
-        return ["en"]
+        return ["en", "de", "pl", "es", "it", "fr", "pt", "hi"]
 
     @property
     def supported_options(self) -> list[str]:


### PR DESCRIPTION
This PR adds the supported languages of the multilingual model to the `supported_languages`

![Bildschirm­foto 2023-05-21 um 12 45 00](https://github.com/carleeno/elevenlabs_tts/assets/1506970/5944e3d5-1b4c-4b09-8dbc-5ff27ec59029)

Without it, it is impossible to select the tts integration in the Assist pipeline if the language is set to e. g. German:

![Bildschirm­foto 2023-05-21 um 12 46 20](https://github.com/carleeno/elevenlabs_tts/assets/1506970/a24b610e-8963-4e73-af1a-6c3842fb485f)
