### PR TITLE
fix: increase request timeout for long TTS messages

### DIFF
--- a/custom_components/elevenlabs_tts/elevenlabs.py
+++ b/custom_components/elevenlabs_tts/elevenlabs.py
@@ -77,7 +77,11 @@ class ElevenLabsClient:
         json_str = orjson.dumps(data)
 
         response = await self.session.post(
-            url, headers=headers, data=json_str, params=params
+            url,
+            headers=headers,
+            data=json_str,
+            params=params,
+            timeout=httpx.Timeout(60),
         )
         response.raise_for_status()
         return response


### PR DESCRIPTION
I noticed that for long TTS messages (> 3 sentences) the requests timed out. I added a timeout of 60s which I think should be enough, but maybe in the future this could be configurable via the options? Or maybe just increase it to be very long? This fixes it for now