### PR TITLE
Fix config option validation

### DIFF
--- a/custom_components/elevenlabs_tts/config_flow.py
+++ b/custom_components/elevenlabs_tts/config_flow.py
@@ -111,13 +111,19 @@ class ElevenlabsTTSOptionsFlowHandler(config_entries.OptionsFlow):
                         default=self.config_entry.options.get(
                             CONF_STABILITY, DEFAULT_STABILITY
                         ),
-                    ): float,
+                    ): vol.All(
+                        vol.Coerce(float),
+                        vol.Range(min=0, max=1),
+                    ),
                     vol.Optional(
                         CONF_SIMILARITY,
                         default=self.config_entry.options.get(
                             CONF_SIMILARITY, DEFAULT_SIMILARITY
                         ),
-                    ): float,
+                    ): vol.All(
+                        vol.Coerce(float),
+                        vol.Range(min=0, max=1),
+                    ),
                     vol.Optional(
                         CONF_MODEL,
                         default=self.config_entry.options.get(
@@ -129,13 +135,16 @@ class ElevenlabsTTSOptionsFlowHandler(config_entries.OptionsFlow):
                         default=self.config_entry.options.get(
                             CONF_OPTIMIZE_LATENCY, DEFAULT_OPTIMIZE_LATENCY
                         ),
-                    ): int,
+                    ): vol.All(int, vol.Range(min=0, max=4)),
                     vol.Optional(
                         CONF_STYLE,
                         default=self.config_entry.options.get(
                             CONF_STYLE, DEFAULT_STYLE
                         ),
-                    ): float,
+                    ): vol.All(
+                        vol.Coerce(float),
+                        vol.Range(min=0, max=1),
+                    ),
                     vol.Optional(
                         CONF_USE_SPEAKER_BOOST,
                         default=self.config_entry.options.get(

--- a/custom_components/elevenlabs_tts/translations/en.json
+++ b/custom_components/elevenlabs_tts/translations/en.json
@@ -28,9 +28,9 @@
                     "stability": "Set the stability of the speech synthesis",
                     "similarity": "Set the clarity/similarity boost of the speech synthesis",
                     "model": "Change the model used for requests",
-                    "optimize_streaming_latency": "Reduce latency at the cost of quality",	
-                    "style": "Style Exaggeration(Not supported in Model V1)",
-                    "use_speaker_boost": "Enable or disable speaker boost(Not supported in Model V1)"					
+                    "optimize_streaming_latency": "Reduce latency at the cost of quality",
+                    "style": "Style exaggeration, not supported in v1 models",
+                    "use_speaker_boost": "Speaker boost, not supported in v1 models"
                 }
             }
         }


### PR DESCRIPTION
the form strips any `.0` from the values, so a 0.0 or 1.0 would be converted to `int`s and fails the validation.

This coerces the ints back to floats, and also adds ranges to further validate the values.