### PR TITLE
Add languages supported by multilingual-v2

### DIFF
--- a/custom_components/elevenlabs_tts/tts.py
+++ b/custom_components/elevenlabs_tts/tts.py
@@ -59,7 +59,37 @@ class ElevenLabsProvider(TextToSpeechEntity):
     @property
     def supported_languages(self) -> list[str]:
         """Return list of supported languages."""
-        return ["en", "de", "pl", "es", "it", "fr", "pt", "hi"]
+        # This is for eleven_multilingual_v2, not all are supported in other models
+        return [
+            "en",  # English
+            "ja",  # Japanese
+            "zh",  # Chinese
+            "de",  # German
+            "hi",  # Hindi
+            "fr",  # French
+            "ko",  # Korean
+            "pt",  # Portuguese
+            "it",  # Italian
+            "es",  # Spanish
+            "id",  # Indonesian
+            "nl",  # Dutch
+            "tr",  # Turkish
+            "fil",  # Filipino
+            "pl",  # Polish
+            "sv",  # Swedish
+            "bg",  # Bulgarian
+            "ro",  # Romanian
+            "ar",  # Arabic
+            "cs",  # Czech
+            "el",  # Greek
+            "fi",  # Finnish
+            "hr",  # Croatian
+            "ms",  # Malay
+            "sk",  # Slovak
+            "da",  # Danish
+            "ta",  # Tamil
+            "uk",  # Ukrainian
+        ]
 
     @property
     def default_options(self):


### PR DESCRIPTION
Fixes #72 

This adds all languages supported by the largest model according to their [docs](https://help.elevenlabs.io/hc/en-us/articles/17883183930129-What-models-do-you-offer-and-what-is-the-difference-between-them-)